### PR TITLE
Fixed bug which broke multiple base64 certificates as input

### DIFF
--- a/zcertificate.go
+++ b/zcertificate.go
@@ -78,7 +78,9 @@ func BreakBase64ByLineAsync(out chan []byte, in io.Reader, wg *sync.WaitGroup) e
 		if err == io.EOF {
 			break
 		}
-		return err
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixed bug in zcertificate.go which prevented submitting multiple certificates to zcertificate to address #6 